### PR TITLE
Unset user dict

### DIFF
--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -206,7 +206,6 @@ def set_user_dict(path):
     )
 
 
-
 def unset_user_dict():
     """Stop applying user dictionary"""
     global _global_jtalk

--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -204,3 +204,12 @@ def set_user_dict(path):
     _global_jtalk = OpenJTalk(
         dn_mecab=OPEN_JTALK_DICT_DIR.encode(path_encoding), user_mecab=path.encode(path_encoding)
     )
+
+
+
+def unset_user_dict():
+    """Stop applying user dictionary"""
+    global _global_jtalk
+    if _global_jtalk is None:
+        _lazy_init()
+    _global_jtalk = OpenJTalk(dn_mecab=OPEN_JTALK_DICT_DIR.encode(path_encoding))


### PR DESCRIPTION
ユーザー辞書の適用をやめるようにする`unset_user_dict`関数を追加します。

ユーザー辞書を適用中はdicファイルの上書きができません。
一旦ユーザー辞書の適用をやめ、dicファイルを上書きしてから再度適用しなおす運用を想定しています。