### PR TITLE
Revert "openjtalkを1.11にアップデート (#6)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/r9y9/open_jtalk.git
 [submodule "lib/hts_engine_API"]
 	path = lib/hts_engine_API
-	url = https://github.com/VOICEVOX/pyopenjtalk.git
+	url = https://github.com/r9y9/hts_engine_API.git


### PR DESCRIPTION
submoduleとして更新できていなかったのでrevertします

This reverts commit 9a99880c7c83707b833ff525195c592414df9678.