### PR TITLE
use safer text2mecab

### DIFF
--- a/pyopenjtalk/openjtalk/text2mecab.pxd
+++ b/pyopenjtalk/openjtalk/text2mecab.pxd
@@ -1,4 +1,4 @@
 # distutils: language = c++
 
 cdef extern from "text2mecab.h":
-    void text2mecab(char *output, const char *input)
+    int text2mecab(char *output, size_t sizeOfOutput, const char *input)


### PR DESCRIPTION
https://github.com/VOICEVOX/open_jtalk/pull/4 に追従
入力テキストがバッファを超えた場合は`RuntimeError("Text is too long")`を送出する