### PR TITLE
#384 openjtalk::run_frontend入力バイト数(<=8192)チェックの追加

### DIFF
--- a/pyopenjtalk/openjtalk.pyx
+++ b/pyopenjtalk/openjtalk.pyx
@@ -166,7 +166,7 @@ cdef class OpenJTalk(object):
           text = text.encode("utf-8")
 
         if len(text) > 8192:
-          raise ValueError("Too long an input value.[Max:" + str(8192) + " Byte]")
+          raise ValueError("Too long an input value.[Max:" + str(8192) + " Byte < your input:" +  str(len(text))  + " Byte]")
         cdef char buff[8192]
 
         text2mecab(buff, text)

--- a/pyopenjtalk/openjtalk.pyx
+++ b/pyopenjtalk/openjtalk.pyx
@@ -164,7 +164,11 @@ cdef class OpenJTalk(object):
         """
         if isinstance(text, str):
           text = text.encode("utf-8")
+
+        if len(text) > 8192:
+          raise ValueError("Too long an input value.[Max:" + 8192 + " Byte]")
         cdef char buff[8192]
+
         text2mecab(buff, text)
         Mecab_analysis(self.mecab, buff)
         mecab2njd(self.njd, Mecab_get_feature(self.mecab), Mecab_get_size(self.mecab))

--- a/pyopenjtalk/openjtalk.pyx
+++ b/pyopenjtalk/openjtalk.pyx
@@ -166,7 +166,7 @@ cdef class OpenJTalk(object):
           text = text.encode("utf-8")
 
         if len(text) > 8192:
-          raise ValueError("Too long an input value.[Max:" + 8192 + " Byte]")
+          raise ValueError("Too long an input value.[Max:" + str(8192) + " Byte]")
         cdef char buff[8192]
 
         text2mecab(buff, text)


### PR DESCRIPTION
入力バイト数が、現在最大とされている8192Byteを超える場合に
`raise ValueError`
を発生させるように修正しました。（最大限変換を頑張る）

engineの`--enable_mock`環境でEngine側が異常終了しない事は確認しました。