### PR TITLE
Merge r9y9 0.2.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,15 @@
 Change log
 ==========
 
-v0.1.6 <2021-xx-xx>
+v0.2.0 <2022-02-06>
 -------------------
+
+* `#29`_: Update binary dependencies (hts_engine_API/open_jtalk)
+
+v0.1.6 <2022-01-29>
+-------------------
+
+* `#27`_: pyopenjtalk cannot be installed in google colab
 
 v0.1.5 <2021-09-18>
 -------------------
@@ -73,3 +80,5 @@ Initial release with OpenJTalk's text processsing functionality
 .. _#22: https://github.com/r9y9/pyopenjtalk/pull/22
 .. _#24: https://github.com/r9y9/pyopenjtalk/pull/24
 .. _#25: https://github.com/r9y9/pyopenjtalk/pull/25
+.. _#27: https://github.com/r9y9/pyopenjtalk/issues/27
+.. _#29: https://github.com/r9y9/pyopenjtalk/pull/29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<v60.0",
     "cython>=0.21.0",
     "numpy<v1.20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<v60.0",
+    "setuptools",
     "cython>=0.21.0",
     "numpy<v1.20.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import Extension, find_packages, setup
 
 platform_is_windows = sys.platform == "win32"
 
-version = "0.1.6"
+version = "0.2.0"
 
 min_cython_ver = "0.21.0"
 try:


### PR DESCRIPTION
https://github.com/r9y9/pyopenjtalk/releases/tag/v0.2.0 の追従です。
openjtalkまわりはVOICEVOXのものを優先しました。