### PR TITLE
BLD: ビルド時に使用するcythonバージョンを制限する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools<v60.0",
-    "cython>=0.28.0, <3.0",
+    "cython>=0.28.0, <3.0", # NOTE: https://github.com/r9y9/pyopenjtalk/issues/55
     "numpy>=1.20.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools<v60.0",
-    "cython>=0.28.0",
+    "cython>=0.28.0, <3.0",
     "numpy>=1.20.0",
 ]
 


### PR DESCRIPTION
## 内容

Cython3.0がリリースされたことによってpyopenjtalkのビルドが失敗するようになりました。
一時的な対策としてビルドに使用するバージョンを制限します。

## 関連 Issue

- ref https://github.com/r9y9/pyopenjtalk/issues/55
