### PR TITLE
Merge upstream 0.3.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[lint]"
+        pip install -e ".[dev]"
     - name: Lint with pysen
       run: |
         pysen run lint

--- a/pyopenjtalk/htsengine.pyx
+++ b/pyopenjtalk/htsengine.pyx
@@ -10,8 +10,8 @@ np.import_array()
 cimport cython
 from libc.stdlib cimport malloc, free
 
-from htsengine cimport HTS_Engine
-from htsengine cimport (
+from .htsengine cimport HTS_Engine
+from .htsengine cimport (
     HTS_Engine_initialize, HTS_Engine_load, HTS_Engine_clear, HTS_Engine_refresh,
     HTS_Engine_get_sampling_frequency, HTS_Engine_get_fperiod,
     HTS_Engine_set_speed, HTS_Engine_add_half_tone,

--- a/pyopenjtalk/openjtalk.pyx
+++ b/pyopenjtalk/openjtalk.pyx
@@ -11,18 +11,18 @@ np.import_array()
 cimport cython
 from libc.stdlib cimport calloc
 
-from openjtalk.mecab cimport Mecab, Mecab_initialize, Mecab_load, Mecab_analysis
-from openjtalk.mecab cimport Mecab_get_feature, Mecab_get_size, Mecab_refresh, Mecab_clear
-from openjtalk.mecab cimport mecab_dict_index, createModel, Model, Tagger, Lattice
-from openjtalk.njd cimport NJD, NJD_initialize, NJD_refresh, NJD_print, NJD_clear
-from openjtalk cimport njd as _njd
-from openjtalk.jpcommon cimport JPCommon, JPCommon_initialize,JPCommon_make_label
-from openjtalk.jpcommon cimport JPCommon_get_label_size, JPCommon_get_label_feature
-from openjtalk.jpcommon cimport JPCommon_refresh, JPCommon_clear
-from openjtalk cimport njd2jpcommon
-from openjtalk.text2mecab cimport text2mecab
-from openjtalk.mecab2njd cimport mecab2njd
-from openjtalk.njd2jpcommon cimport njd2jpcommon
+from .openjtalk.mecab cimport Mecab, Mecab_initialize, Mecab_load, Mecab_analysis
+from .openjtalk.mecab cimport Mecab_get_feature, Mecab_get_size, Mecab_refresh, Mecab_clear
+from .openjtalk.mecab cimport mecab_dict_index, createModel, Model, Tagger, Lattice
+from .openjtalk.njd cimport NJD, NJD_initialize, NJD_refresh, NJD_print, NJD_clear
+from .openjtalk cimport njd as _njd
+from .openjtalk.jpcommon cimport JPCommon, JPCommon_initialize,JPCommon_make_label
+from .openjtalk.jpcommon cimport JPCommon_get_label_size, JPCommon_get_label_feature
+from .openjtalk.jpcommon cimport JPCommon_refresh, JPCommon_clear
+from .openjtalk cimport njd2jpcommon
+from .openjtalk.text2mecab cimport text2mecab
+from .openjtalk.mecab2njd cimport mecab2njd
+from .openjtalk.njd2jpcommon cimport njd2jpcommon
 from libc.string cimport strlen
 
 cdef inline int Mecab_load_ex(Mecab *m, char* dicdir, char* userdic):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools<v60.0",
-    "cython>=0.28.0, <3.0", # NOTE: https://github.com/r9y9/pyopenjtalk/issues/55
-    "numpy>=1.20.0",
+    "cython>=0.28.0,<3.0.0",
+    "cmake",
+    "numpy>=1.25.0; python_version>='3.9'",
+    "oldest-supported-numpy; python_version<'3.9'",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.pysen]
 version = "0.10.2"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import Extension, find_packages, setup
 
 platform_is_windows = sys.platform == "win32"
 
-version = "0.3.0"
+version = "0.3.2"
 
 min_cython_ver = "0.21.0"
 try:
@@ -69,6 +69,43 @@ else:
     cmdclass = {}
     if not os.path.exists(join("pyopenjtalk", "openjtalk" + ext)):
         raise RuntimeError("Cython is required to generate C++ code")
+
+
+def check_cmake_in_path():
+    try:
+        result = subprocess.run(
+            ["cmake", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0:
+            # CMake is in the system path
+            return True, result.stdout.strip()
+        else:
+            # CMake is not in the system path
+            return False, None
+    except FileNotFoundError:
+        # CMake command not found
+        return False, None
+
+
+if os.name == "nt":  # Check if the OS is Windows
+    # Check if CMake is in the system path
+    cmake_found, cmake_version = check_cmake_in_path()
+
+    if cmake_found:
+        print(
+            f"CMake is in the system path. Version: \
+              {cmake_version}"
+        )
+    else:
+        raise SystemError(
+            "CMake is not found in the \
+                          system path. Make sure CMake \
+                          is installed and in the system \
+                          path."
+        )
 
 
 # Workaround for `distutils.spawn` problem on Windows python < 3.9
@@ -277,7 +314,6 @@ setup(
     cmdclass=cmdclass,
     install_requires=[
         "numpy >= 1.20.0",
-        "cython >= " + min_cython_ver,
         "six",
         "tqdm",
     ],
@@ -291,7 +327,8 @@ setup(
             "ipython",
             "jupyter",
         ],
-        "lint": [
+        "dev": [
+            "cython >= " + min_cython_ver + ",<3.0.0",
             "pysen",
             "types-setuptools",
             "mypy<=0.910",
@@ -301,6 +338,7 @@ setup(
             "flake8-bugbear",
             "isort>=4.3,<5.2.0",
             "types-decorator",
+            "importlib-metadata<5.0",
         ],
         "test": ["pytest", "scipy"],
         "marine": ["marine>=0.0.5"],


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/pyopenjtalk/pull/19

でpython 3.7用のテストが落ちていたっぽいので、フォーク元のバージョン0.3.2をマージしてみます。
要forwardマージ。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
