### PR TITLE
fix: cmake のバージョンを4未満に固定

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools<v60.0",
     "cython>=0.28.0,<3.0.0",
-    "cmake",
+    "cmake<4.0.0",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",
 ]


### PR DESCRIPTION
## 内容
- cmake のバージョンを 4未満に固定するようにしました。
  - voicevox_engine のビルドが cmake 4 ではコケるため、固定するように

## 関連 Issue
ref: https://github.com/VOICEVOX/voicevox_engine/issues/1568